### PR TITLE
feat: 무한 스크롤 구현(#62)

### DIFF
--- a/src/api/getProductsByCategory.js
+++ b/src/api/getProductsByCategory.js
@@ -1,5 +1,7 @@
-const getProductsByCategory = async ({ categoryName }) => {
-  const response = await fetch(`https://dummyjson.com/products/category/${categoryName}`);
+const getProductsByCategory = async ({ categoryName, limit = 0, skip = 0 }) => {
+  const response = await fetch(
+    `https://dummyjson.com/products/category/${categoryName}?limit=${limit}&skip=${skip}`,
+  );
 
   if (!response.ok) {
     throw Error('오류가 발생했습니다.');

--- a/src/components/ui/common/ProductCardContainer.jsx
+++ b/src/components/ui/common/ProductCardContainer.jsx
@@ -1,20 +1,13 @@
 import ProductCard from '@components/ui/common/ProductCard';
 
-const ProductCardContainer = ({ isLoading, products }) => {
+const ProductCardContainer = ({ isLoading, products, skeletonSize = 10 }) => {
   return (
     <div className='grid max-w-fit grid-cols-2 justify-items-center gap-4 md:grid-cols-3 xl:grid-cols-4'>
-      {isLoading && Array.from({ length: 8 }).map((_, idx) => <ProductCard key={idx} isLoading />)}
-      {!isLoading &&
-        products.map(({ id, title, price, images: [image] }) => (
-          <ProductCard
-            key={id}
-            id={id}
-            title={title}
-            price={price}
-            isLoading={false}
-            image={image}
-          />
-        ))}
+      {products.map(({ id, title, price, images: [image] }) => (
+        <ProductCard key={id} id={id} title={title} price={price} isLoading={false} image={image} />
+      ))}
+      {isLoading &&
+        Array.from({ length: skeletonSize }).map((_, idx) => <ProductCard key={idx} isLoading />)}
     </div>
   );
 };

--- a/src/hooks/useIntersect.js
+++ b/src/hooks/useIntersect.js
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const useIntersect = ({ onIntersect, options }) => {
+  const ref = useRef(null);
+  const callback = useCallback(
+    (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          onIntersect(entry, observer);
+        }
+      });
+    },
+    [onIntersect],
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, options]);
+
+  return ref;
+};
+
+export default useIntersect;

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,0 +1,27 @@
+import useFetch from '@hooks/useFetch';
+import { useCallback, useEffect, useState } from 'react';
+
+const usePagination = ({ query, options, countPerPage }) => {
+  const [currentSkip, setCurrentSkip] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(true);
+
+  const { data, isLoading, error } = useFetch({
+    query,
+    options: { ...options, limit: countPerPage, skip: currentSkip },
+  });
+
+  const fetchNextPage = useCallback(() => {
+    if (hasNextPage) {
+      setCurrentSkip((prev) => prev + countPerPage);
+    }
+  }, [countPerPage, hasNextPage]);
+
+  useEffect(() => {
+    if (data) {
+      setHasNextPage(data.products.length === countPerPage);
+    }
+  }, [data, countPerPage]);
+
+  return { data, isLoading, error, fetchNextPage, hasNextPage };
+};
+export default usePagination;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62

## 📝작업 내용

> 무한 스크롤 구현
- api/getProductsByCategory가 limit, skip을 받도록 수정
- useIntersect 훅 추가
- usePagination 훅 추가
- Products에 무한 스크롤 적용
- ProductCardContainer의 스켈레톤 위치 수정, 기존 데이터가 로딩 중일때도 표시되게 수정, 스켈레톤 개수를 prop으로 받도록 수정


