### PR TITLE
feat: Products 안의 인피니티 스크롤 관련 코드들을 분리(#69)

### DIFF
--- a/src/components/Target.jsx
+++ b/src/components/Target.jsx
@@ -1,0 +1,6 @@
+// 인피니티 스크롤 적용시 사용
+const Target = ({ ref }) => {
+  return <div className='h-[1px]' ref={ref}></div>;
+};
+
+export default Target;

--- a/src/hooks/useProductInfinityScroll.js
+++ b/src/hooks/useProductInfinityScroll.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import usePagination from '@hooks/usePagination';
+import useFetch from '@hooks/useFetch';
+import useIntersect from '@hooks/useIntersect';
+
+const useProductInfinityScroll = ({ countPerPage, query, options }) => {
+  const [products, setProducts] = useState([]);
+
+  const { fetchNextPageQuery, hasNextPage, setHasNextPage, setCurrentSkip } = usePagination({
+    query,
+    options,
+    countPerPage,
+  });
+  const { data, isLoading, error } = useFetch({ query: fetchNextPageQuery });
+
+  const total = data?.total ?? 0;
+  const ref = useIntersect({
+    onIntersect: async (entry, observer) => {
+      observer.unobserve(entry.target);
+      if (!isLoading && hasNextPage) {
+        setCurrentSkip((prev) => prev + countPerPage);
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (data && data.products) {
+      setProducts((prevProducts) => {
+        const existingProductIds = new Set(prevProducts.map((product) => product.id));
+        const nonDuplicatedProducts = data.products.filter(
+          (product) => !existingProductIds.has(product.id),
+        );
+
+        return [...prevProducts, ...nonDuplicatedProducts];
+      });
+      setHasNextPage(data.products.length === countPerPage);
+    }
+  }, [data, setHasNextPage, countPerPage]);
+
+  return { products, total, isLoading, error, hasNextPage, ref };
+};
+
+export default useProductInfinityScroll;

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -3,40 +3,18 @@ import { DEFAULT_META_DATA_URL } from '@constants/url';
 import { useParams } from 'react-router';
 import ProductCardContainer from '@components/ui/common/ProductCardContainer';
 import getProductsByCategory from '@api/getProductsByCategory';
-import { useEffect, useState } from 'react';
-import usePagination from '@hooks/usePagination';
-import useIntersect from '@hooks/useIntersect';
-import useFetch from '@hooks/useFetch';
+import useProductInfinityScroll from '@hooks/useProductInfinityScroll';
+import Target from '@components/Target';
 
 const Products = () => {
-  const [products, setProducts] = useState([]);
-  const { catalog } = useParams();
   const countPerPage = 6;
+  const { catalog } = useParams();
 
-  const { fetchNextPageQuery, hasNextPage, setHasNextPage, setCurrentSkip } = usePagination({
+  const { products, total, isLoading, error, ref } = useProductInfinityScroll({
+    countPerPage,
     query: getProductsByCategory,
     options: { categoryName: catalog },
-    countPerPage,
   });
-
-  const { data, isLoading, error } = useFetch({ query: fetchNextPageQuery });
-
-  const total = data?.total ?? 0;
-  const ref = useIntersect({
-    onIntersect: async (entry, observer) => {
-      observer.unobserve(entry.target);
-      if (!isLoading && hasNextPage) {
-        setCurrentSkip((prev) => prev + countPerPage);
-      }
-    },
-  });
-
-  useEffect(() => {
-    if (data && data.products) {
-      setProducts((prevProducts) => [...prevProducts, ...data.products]);
-      setHasNextPage(data.products.length === countPerPage);
-    }
-  }, [data, setHasNextPage]);
 
   if (error) {
     console.log(error);
@@ -55,16 +33,16 @@ const Products = () => {
       <div className='flex justify-center'>
         <div className='flex flex-col items-start'>
           <div>Products Result : {total}</div>
-          <ProductCardContainer products={products} isLoading={isLoading} skeletonSize={6} />
+          <ProductCardContainer
+            products={products}
+            isLoading={isLoading}
+            skeletonSize={countPerPage}
+          />
           <Target ref={ref} />
         </div>
       </div>
     </div>
   );
 };
-
-function Target({ ref }) {
-  return <div className='h-[1px]' ref={ref}></div>;
-}
 
 export default Products;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #69

## 📝작업 내용

> Products 안의 인피니티 스크롤 관련 코드들을 분리
- useProductInfinityScroll 훅으로 분리
- Products 코드를 useProductInfinityScroll 사용에 맞춰서 수정
- Target을 src/components로 분리