### PR TITLE
feat: Products 페이지에 필터 추가(#71)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ function App() {
     { path: 'cart', element: <Cart /> },
     { path: 'user-info', element: <UserInfo /> },
     { path: 'products/:catalog', element: <Products /> },
+    { path: 'products', element: <Products /> },
     { path: '*', element: <NotFound /> },
   ];
 

--- a/src/api/getAllProducts.js
+++ b/src/api/getAllProducts.js
@@ -1,0 +1,11 @@
+const getAllProducts = async ({ limit = 0, skip = 0 }) => {
+  const response = await fetch(`https://dummyjson.com/products?limit=${limit}&skip=${skip}`);
+
+  if (!response.ok) {
+    throw Error('오류가 발생했습니다.');
+  }
+
+  return response;
+};
+
+export default getAllProducts;

--- a/src/components/ui/common/Dropdown.jsx
+++ b/src/components/ui/common/Dropdown.jsx
@@ -1,0 +1,33 @@
+import cn from '@utils/cn';
+import React, { useState } from 'react';
+import ArrowDown from '@assets/Images/icons/24px/icon_down_arrow.svg?react';
+import Button from '@components/ui/buttons/Button';
+
+const DropdownTitle = ({ dropdownTitle, onClick, isOpen }) => {
+  return (
+    <Button
+      onClick={onClick}
+      className='flex h-[48px] w-full items-center justify-between rounded-none border-0 border-b-[0.5px] border-b-[#B5B5B5] text-[18px]/[24px] font-medium tracking-[3%]'
+    >
+      {dropdownTitle}
+      <div className={cn('stroke-black stroke-2', { 'rotate-180': isOpen })}>{<ArrowDown />}</div>
+    </Button>
+  );
+};
+
+const Dropdown = ({ className, children, dropdownTitle }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className={cn('flex flex-col gap-6', className)}>
+      <DropdownTitle
+        onClick={() => setIsOpen((prev) => !prev)}
+        isOpen={isOpen}
+        dropdownTitle={dropdownTitle}
+      />
+      <div className={cn('hidden', { block: isOpen })}>{children}</div>
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/ui/common/ProductCardContainer.jsx
+++ b/src/components/ui/common/ProductCardContainer.jsx
@@ -1,8 +1,14 @@
 import ProductCard from '@components/ui/common/ProductCard';
+import cn from '@utils/cn';
 
-const ProductCardContainer = ({ isLoading, products, skeletonSize = 10 }) => {
+const ProductCardContainer = ({ isLoading, products, skeletonSize = 10, className }) => {
   return (
-    <div className='grid max-w-fit grid-cols-2 justify-items-center gap-4 md:grid-cols-3 xl:grid-cols-4'>
+    <div
+      className={cn(
+        'grid max-w-fit grid-cols-2 justify-items-center gap-4 md:grid-cols-3 xl:grid-cols-4',
+        className,
+      )}
+    >
       {products.map(({ id, title, price, images: [image] }) => (
         <ProductCard key={id} id={id} title={title} price={price} isLoading={false} image={image} />
       ))}

--- a/src/components/ui/products/Filter.jsx
+++ b/src/components/ui/products/Filter.jsx
@@ -1,0 +1,63 @@
+import Dropdown from '@components/ui/common/Dropdown';
+import cn from '@utils/cn';
+import React from 'react';
+import getCategoryList from '@api/getCategoryList';
+import useFetch from '@hooks/useFetch';
+import { useNavigate, useParams } from 'react-router';
+
+const Filter = ({ className }) => {
+  const DROPDOWN_ITEMS = [
+    {
+      title: 'Category',
+      Children: CategoryItem,
+    },
+  ];
+
+  return (
+    <div className={cn('w-full max-w-[256px] gap-6', className)}>
+      {DROPDOWN_ITEMS.map(({ title, Children }) => (
+        <Dropdown className={'w-full max-w-[256px]'} key={title} dropdownTitle={title}>
+          <Children />
+        </Dropdown>
+      ))}
+    </div>
+  );
+};
+
+function CategoryItem() {
+  const navigate = useNavigate();
+  const { data: categories, isLoading, error } = useFetch({ query: getCategoryList });
+  const { catalog } = useParams();
+
+  if (isLoading) {
+    return <div>로딩 중입니다.</div>;
+  }
+
+  if (error) {
+    return <div>에러가 발생했습니다.</div>;
+  }
+
+  return (
+    <div>
+      {categories?.map((category) => (
+        <div className='flex gap-2' key={category}>
+          <input
+            type='checkbox'
+            checked={category === catalog}
+            id={`${category}`}
+            onChange={() => {
+              if (catalog !== category) {
+                navigate(`/products/${category}`);
+              } else {
+                navigate('/products');
+              }
+            }}
+          />
+          <label htmlFor={`${category}`}>{category}</label>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default Filter;

--- a/src/hooks/useProductInfinityScroll.js
+++ b/src/hooks/useProductInfinityScroll.js
@@ -1,10 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import usePagination from '@hooks/usePagination';
 import useFetch from '@hooks/useFetch';
 import useIntersect from '@hooks/useIntersect';
+import { isEqual } from 'lodash';
 
 const useProductInfinityScroll = ({ countPerPage, query, options }) => {
   const [products, setProducts] = useState([]);
+
+  const prevQueryRef = useRef(query);
+  const prevOptionsRef = useRef(options);
 
   const { fetchNextPageQuery, hasNextPage, setHasNextPage, setCurrentSkip } = usePagination({
     query,
@@ -22,6 +26,16 @@ const useProductInfinityScroll = ({ countPerPage, query, options }) => {
       }
     },
   });
+
+  useEffect(() => {
+    if (query !== prevQueryRef.current || !isEqual(options, prevOptionsRef.current)) {
+      setProducts([]);
+      setCurrentSkip(0);
+      setHasNextPage(true);
+      prevQueryRef.current = query;
+      prevOptionsRef.current = options;
+    }
+  }, [options, query, setCurrentSkip, setHasNextPage]);
 
   useEffect(() => {
     if (data && data.products) {

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -5,15 +5,23 @@ import ProductCardContainer from '@components/ui/common/ProductCardContainer';
 import getProductsByCategory from '@api/getProductsByCategory';
 import useProductInfinityScroll from '@hooks/useProductInfinityScroll';
 import Target from '@components/Target';
+import getAllProducts from '@api/getAllProducts';
+import Filter from '@components/ui/products/Filter';
 
 const Products = () => {
   const countPerPage = 6;
   const { catalog } = useParams();
 
+  const query = catalog ? getProductsByCategory : getAllProducts;
+  const options = catalog ? { categoryName: catalog } : null;
+  const url = catalog
+    ? `${DEFAULT_META_DATA_URL}/products/${catalog}`
+    : `${DEFAULT_META_DATA_URL}/products`;
+
   const { products, total, isLoading, error, ref } = useProductInfinityScroll({
     countPerPage,
-    query: getProductsByCategory,
-    options: { categoryName: catalog },
+    query,
+    options,
   });
 
   if (error) {
@@ -22,14 +30,15 @@ const Products = () => {
   }
 
   return (
-    <div>
+    <div className='flex justify-center gap-8'>
       <Metadata
         title='cyber 메인 페이지'
-        url={`${DEFAULT_META_DATA_URL}/${catalog}`}
+        url={url}
         image={`${DEFAULT_META_DATA_URL}/og_product_page.png`}
         imageAlt='cyber 상품 페이지 이미지입니다. '
         description='cyber의 상품 페이지입니다.'
       />
+      <Filter />
       <div className='flex justify-center'>
         <div className='flex flex-col items-start'>
           <div>Products Result : {total}</div>
@@ -37,6 +46,7 @@ const Products = () => {
             products={products}
             isLoading={isLoading}
             skeletonSize={countPerPage}
+            className={'md:grid-cols-2 xl:grid-cols-3'}
           />
           <Target ref={ref} />
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71

## 📝작업 내용

> Products 페이지에 필터 추가
- 전체 products를 불러오는 getAllProducts API 추가
- /products path 추가
- Dropdown 컴포넌트 구현
- ProductCardContainer가 className을 받도록 수정
- Filter 컴포넌트 추가
- useProductInfinityScroll에서 이전 query, options랑 비교 후 다른 값이면 products 초기화
- Products 페이지에 카테고리가 있는 경우와 없는 경우 분기 처리, Filter 추가


