### PR TITLE
refactor: 바텀시트 수정(#77)

### DIFF
--- a/src/constants/bottomSheet.js
+++ b/src/constants/bottomSheet.js
@@ -1,3 +1,3 @@
-export const MIN_Y = 60;
+export const MIN_Y = 120;
 export const MAX_Y = window.innerHeight - 80;
 export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y;

--- a/src/hooks/useBottomSheet.js
+++ b/src/hooks/useBottomSheet.js
@@ -17,8 +17,8 @@ export function useBottomSheet() {
       touchY: 0,
     },
     touchMove: {
-      prevTouchY: 0,
-      movingDirection: 'none',
+      prevTouchY: null,
+      movingDirection: MOVING_DIRECTION.NONE,
     },
     isContentAreaTouched: false,
   });
@@ -57,16 +57,16 @@ export function useBottomSheet() {
       const { touchStart, touchMove } = metrics.current;
       const currentTouch = e.touches[0];
 
-      if (touchMove.prevTouchY === undefined) {
+      if (touchMove.prevTouchY === null) {
         touchMove.prevTouchY = touchStart.touchY;
       }
 
       if (touchMove.prevTouchY < currentTouch.clientY) {
         touchMove.movingDirection = MOVING_DIRECTION.DOWN;
-      }
-
-      if (touchMove.prevTouchY > currentTouch.clientY) {
+      } else if (touchMove.prevTouchY > currentTouch.clientY) {
         touchMove.movingDirection = MOVING_DIRECTION.UP;
+      } else {
+        touchMove.movingDirection = MOVING_DIRECTION.NONE;
       }
 
       if (canUserMoveBottomSheet()) {
@@ -85,7 +85,7 @@ export function useBottomSheet() {
 
         currentSheet.style.setProperty('transform', `translateY(${nextSheetY - MAX_Y}px)`);
       } else {
-        document.body.style.overflow = 'hidden';
+        document.body.style.overflowY = 'hidden';
       }
     };
 
@@ -95,7 +95,7 @@ export function useBottomSheet() {
       const currentSheet = sheetRef.current;
       const { touchMove } = metrics.current;
 
-      const currentSheetY = sheetRef.current.getBoundingClientRect().y;
+      const currentSheetY = currentSheet.getBoundingClientRect().y;
 
       if (currentSheetY !== MIN_Y) {
         if (touchMove.movingDirection === MOVING_DIRECTION.DOWN) {
@@ -113,8 +113,8 @@ export function useBottomSheet() {
           touchY: 0,
         },
         touchMove: {
-          prevTouchY: 0,
-          movingDirection: 'none',
+          prevTouchY: null,
+          movingDirection: MOVING_DIRECTION.NONE,
         },
         isContentAreaTouched: false,
       };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #77

## 📝작업 내용

> 바텀시트 수정
- MIN_Y 값 수정(60 -> 120)
- 값 초기화 할 때 prevTouch값을 null로 초기화
- movingDirection에도 상수 사용
- movingDirection 결정 시 UP, DOWN이 아니면 NONE이 적용되도록 수정
- overflow를 overflowY로 변경
- sheetRef.current를 가져와서 사용하는 부분을 currentRef를 가져오도록 수정

