### PR TITLE
refactor: 바텀시트 코드 개선(#80)

### DIFF
--- a/src/components/ui/common/BottomSheet.jsx
+++ b/src/components/ui/common/BottomSheet.jsx
@@ -1,7 +1,11 @@
 import { useBottomSheet } from '@hooks/useBottomSheet';
 import cn from '@utils/cn';
 import React from 'react';
-import { BOTTOM_SHEET_HEIGHT } from '@constants/bottomSheet';
+import {
+  BOTTOM_SHEET_CONTENT_HEIGHT,
+  BOTTOM_SHEET_HEADER_HEIGHT,
+  BOTTOM_SHEET_HEIGHT,
+} from '@constants/bottomSheet';
 
 const BottomSheet = ({ children, className }) => {
   const { sheetRef, contentRef } = useBottomSheet();
@@ -12,20 +16,23 @@ const BottomSheet = ({ children, className }) => {
       className={cn(
         'rounded-t-[8px]',
         'shadow-[0px_0px_10px_rgba(0,0,0,0.4)]',
-        'fixed top-[calc(100%_-_48px)] right-0 left-0',
+        'fixed right-0 left-0',
         'z-1',
         'flex flex-col items-center',
         'bg-white',
         'transition-[transform_150ms_ease-out]',
         className,
       )}
-      style={{ height: BOTTOM_SHEET_HEIGHT }}
+      style={{
+        height: BOTTOM_SHEET_HEIGHT,
+        top: `calc(100% - ${BOTTOM_SHEET_HEADER_HEIGHT}px)`,
+      }}
     >
       <BottomSheetHeader />
       <div
-        className='mb-8 flex h-full w-full justify-center overflow-auto px-8'
+        className='h-full w-full overflow-y-auto px-8 pb-8'
         ref={contentRef}
-        style={{ WebkitOverflowScrolling: 'touch' }}
+        style={{ WebkitOverflowScrolling: 'touch', height: BOTTOM_SHEET_CONTENT_HEIGHT }}
       >
         {children}
       </div>
@@ -35,7 +42,10 @@ const BottomSheet = ({ children, className }) => {
 
 function BottomSheetHeader() {
   return (
-    <div className='relative h-12 rounded-t-[8px] pt-4 pb-1'>
+    <div
+      className='relative rounded-t-[8px] pt-4 pb-1'
+      style={{ height: BOTTOM_SHEET_HEADER_HEIGHT }}
+    >
       <div className='h-1 w-8 rounded-[2px] bg-[#d0d0d0]'></div>
     </div>
   );

--- a/src/constants/bottomSheet.js
+++ b/src/constants/bottomSheet.js
@@ -1,3 +1,5 @@
-export const MIN_Y = 120;
-export const MAX_Y = window.innerHeight - 80;
-export const BOTTOM_SHEET_HEIGHT = window.innerHeight - MIN_Y;
+export const BOTTOM_SHEET_OPEN_Y = 120;
+export const BOTTOM_SHEET_HEADER_HEIGHT = 48;
+export const BOTTOM_SHEET_CLOSED_Y = window.innerHeight - BOTTOM_SHEET_HEADER_HEIGHT;
+export const BOTTOM_SHEET_HEIGHT = window.innerHeight - BOTTOM_SHEET_OPEN_Y;
+export const BOTTOM_SHEET_CONTENT_HEIGHT = BOTTOM_SHEET_HEIGHT - BOTTOM_SHEET_HEADER_HEIGHT;

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -68,6 +68,7 @@ const Products = () => {
       </section>
       <BottomSheet className={'md:hidden'}>
         <Filter className={'w-full max-w-full'} dropdownClassName={'max-w-full'} />
+        <Filter className={'w-full max-w-full'} dropdownClassName={'max-w-full'} />
       </BottomSheet>
     </main>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #80

## 📝작업 내용

> 바텀시트 코드 개선
- 상수로 바텀시트 높이, 바텀시트 헤더 높이, 바텀시트 컨텐츠 높이 지정
- 상수 이름을 직관적으로 변경, 헤더 높이, 컨텐츠 높이 추가
- prevTouch를 handleTouchStart에서 지정, 콘텐츠 영역 선택했는지 판단, transition 비움
- 스크롤 가능한 경우에만 preventDefault 사용
- touchMove에서 prevTouch 업데이트
- 중간 값 기준으로 방향을 판단하는 로직 추가
- 클린업 함수에서 overflowY를 auto로 지정
- 내부 드래그 테스트를 위해서 Products의 필터를 두개로 지정


