### PR TITLE
refactor: Products페이지에서 category가 한번만 렌더링되게 수정(#91)

### DIFF
--- a/src/components/ui/products/Filter.jsx
+++ b/src/components/ui/products/Filter.jsx
@@ -1,16 +1,18 @@
 import Dropdown from '@components/ui/common/Dropdown';
 import cn from '@utils/cn';
 import React from 'react';
-import getCategoryList from '@api/getCategoryList';
-import useFetch from '@hooks/useFetch';
 import { useNavigate, useParams } from 'react-router';
 import { PATH } from '@constants/url';
 
-const Filter = ({ className, dropdownClassName }) => {
+const Filter = ({ className, dropdownClassName, ...rest }) => {
+  const { categories, categoryIsLoading, categoryError } = rest;
+
   const DROPDOWN_ITEMS = [
     {
       title: 'Category',
-      Children: CategoryItem,
+      Children: () => (
+        <CategoryItem data={categories} isLoading={categoryIsLoading} error={categoryError} />
+      ),
     },
   ];
 
@@ -29,9 +31,8 @@ const Filter = ({ className, dropdownClassName }) => {
   );
 };
 
-function CategoryItem() {
+function CategoryItem({ data, isLoading, error }) {
   const navigate = useNavigate();
-  const { data: categories, isLoading, error } = useFetch({ query: getCategoryList });
   const { catalog } = useParams();
 
   if (isLoading) {
@@ -44,7 +45,7 @@ function CategoryItem() {
 
   return (
     <div>
-      {categories?.map((category) => (
+      {data?.map((category) => (
         <div className='flex gap-2' key={category}>
           <input
             type='checkbox'

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -7,6 +7,8 @@ import useProductInfinityScroll from '@hooks/useProductInfinityScroll';
 import Target from '@components/Target';
 import getAllProducts from '@api/getAllProducts';
 import Filter from '@components/ui/products/Filter';
+import useFetch from '@hooks/useFetch';
+import getCategoryList from '@api/getCategoryList';
 import Button from '@components/ui/buttons/Button';
 import FilterIcon from '@assets/Images/icons/24px/icon_filter.svg?react';
 import ChevronDownIcon from '@assets/Images/icons/24px/icon_chevron_down.svg?react';
@@ -28,6 +30,12 @@ const Products = () => {
     query,
     options,
   });
+
+  const {
+    data: categories,
+    isLoading: categoryLoading,
+    error: categoryError,
+  } = useFetch({ query: getCategoryList });
 
   if (error) {
     console.log(error);
@@ -52,7 +60,12 @@ const Products = () => {
         </FilterBtn>
       </section>
       <section className='flex justify-center gap-8'>
-        <Filter className={'hidden md:flex md:max-w-[200px] lg:max-w-[256px]'} />
+        <Filter
+          categories={categories}
+          categoryIsLoading={categoryLoading}
+          categoryError={categoryError}
+          className={'hidden md:flex md:max-w-[200px] lg:max-w-[256px]'}
+        />
         <div className='flex justify-center'>
           <div className='flex flex-col items-start'>
             <div>Products Result : {total}</div>
@@ -67,8 +80,20 @@ const Products = () => {
         </div>
       </section>
       <BottomSheet className={'md:hidden'}>
-        <Filter className={'w-full max-w-full'} dropdownClassName={'max-w-full'} />
-        <Filter className={'w-full max-w-full'} dropdownClassName={'max-w-full'} />
+        <Filter
+          categories={categories}
+          categoryIsLoading={categoryLoading}
+          categoryError={categoryError}
+          className={'w-full max-w-full'}
+          dropdownClassName={'max-w-full'}
+        />
+        <Filter
+          categories={categories}
+          categoryIsLoading={categoryLoading}
+          categoryError={categoryError}
+          className={'w-full max-w-full'}
+          dropdownClassName={'max-w-full'}
+        />
       </BottomSheet>
     </main>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91

## 📝작업 내용

> Products페이지에서 category가 한번만 렌더링되게 수정
- Filter에서 데이터 페칭을 하지 않고 Products에서 한번에 데이터 페칭
- CategoryItem이 데이터를 props로 받아서 사용하도록 수정

