### PR TITLE
feat: products 배열의 길이가 0이 아닐때만 onIntersect 함수 실행(#95)

### DIFF
--- a/src/hooks/useIntersect.js
+++ b/src/hooks/useIntersect.js
@@ -1,16 +1,20 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-const useIntersect = ({ onIntersect, options }) => {
+const useIntersect = ({ onIntersect, options, disabled = false }) => {
   const ref = useRef(null);
   const callback = useCallback(
     (entries, observer) => {
       entries.forEach((entry) => {
+        if (disabled) {
+          return;
+        }
+
         if (entry.isIntersecting) {
           onIntersect(entry, observer);
         }
       });
     },
-    [onIntersect],
+    [onIntersect, disabled],
   );
 
   useEffect(() => {

--- a/src/hooks/useProductInfinityScroll.js
+++ b/src/hooks/useProductInfinityScroll.js
@@ -25,6 +25,7 @@ const useProductInfinityScroll = ({ countPerPage, query, options }) => {
         setCurrentSkip((prev) => prev + countPerPage);
       }
     },
+    disabled: products.length === 0,
   });
 
   useEffect(() => {

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -43,7 +43,7 @@ const Products = () => {
   }
 
   return (
-    <main>
+    <div>
       <Metadata
         title='cyber Products 페이지'
         url={url}
@@ -95,7 +95,7 @@ const Products = () => {
           dropdownClassName={'max-w-full'}
         />
       </BottomSheet>
-    </main>
+    </div>
   );
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #95

## 📝작업 내용

> products 배열의 길이가 0이 아닐때만 onIntersect 함수 실행
- useIntersect가 disabled 가능하게 수정
- useProductsInfinityScroll에서 products 배열의 길이가 0이 아닐때만 onIntersect 함수 실행
- Products의 main태그를 div로 변경


