### PR TITLE
fix: 무한스크롤시 푸터가 겹치는 문제 해결(#101)

### DIFF
--- a/src/components/ui/common/ProductCardContainerSkeleton.jsx
+++ b/src/components/ui/common/ProductCardContainerSkeleton.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import cn from '@utils/cn';
+import ProductCardSkeleton from '@components/ui/common/ProductCardSkeleton';
+
+const ProductCardContainerSkeleton = ({ skeletonSize = 10, className }) => {
+  return (
+    <div
+      className={cn(
+        'grid max-w-fit grid-cols-2 justify-items-center gap-4 md:grid-cols-3 xl:grid-cols-4',
+        className,
+      )}
+    >
+      {Array.from({ length: skeletonSize }).map((_, idx) => (
+        <ProductCardSkeleton key={idx} />
+      ))}
+    </div>
+  );
+};
+
+export default ProductCardContainerSkeleton;

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -15,6 +15,7 @@ import BottomSheet from '@components/ui/common/BottomSheet';
 import { useMemo } from 'react';
 import FilterBtn from '@components/ui/buttons/FilterBtn';
 import useIsMobileDevice from '@hooks/useIsMobileDevice';
+import ProductCardContainerSkeleton from '@components/ui/common/ProductCardContainerSkeleton';
 
 const Products = () => {
   const countPerPage = 6;
@@ -27,11 +28,13 @@ const Products = () => {
     ? `${DEFAULT_META_DATA_URL}${PATH.PRODUCTS}/${catalog}`
     : `${DEFAULT_META_DATA_URL}${PATH.PRODUCTS}`;
 
-  const { data, total, isLoading, error, ref } = useInfinityScroll({
+  const { data, total, isLoading, error, ref, hasNextPage } = useInfinityScroll({
     countPerPage,
     query,
     options,
   });
+
+  const isLoadingDone = !hasNextPage && !isLoading;
 
   const {
     data: categoryData,
@@ -75,11 +78,13 @@ const Products = () => {
             <div>Products Result : {total}</div>
             <ProductCardContainer
               products={data}
-              isLoading={isLoading}
               skeletonSize={countPerPage}
               className={'md:grid-cols-2 xl:grid-cols-3'}
             />
             <Target ref={ref} />
+            {!isLoadingDone && (
+              <ProductCardContainerSkeleton className={'md:grid-cols-2 xl:grid-cols-3'} />
+            )}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #101

## 📝작업 내용

> 무한스크롤시 푸터가 겹치는 문제 해결
- ProductCardContainerSkeleton 추가
- Target 위치를 스켈레톤 위쪽으로 지정
- 로딩이 끝났는지 판단하는 isLoadingDone을 사용해서 스켈레톤 표시


